### PR TITLE
CoordinatorLayout-behavior for Snackbar

### DIFF
--- a/FABToolbar/app/src/main/java/com/github/fafaldo/fabtoolbar/sample/MainActivity.java
+++ b/FABToolbar/app/src/main/java/com/github/fafaldo/fabtoolbar/sample/MainActivity.java
@@ -1,6 +1,7 @@
 package com.github.fafaldo.fabtoolbar.sample;
 
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.AdapterView;
@@ -45,6 +46,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 layout.show();
+            }
+        });
+        list.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
+            @Override
+            public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
+                Snackbar.make(layout, "Snackbar", Snackbar.LENGTH_SHORT).show();
+                return true;
             }
         });
 

--- a/FABToolbar/app/src/main/res/layout/activity_main.xml
+++ b/FABToolbar/app/src/main/res/layout/activity_main.xml
@@ -1,4 +1,5 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -79,4 +80,4 @@
 
     </com.github.fafaldo.fabtoolbar.widget.FABToolbarLayout>
 
-</RelativeLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/FABToolbar/library/build.gradle
+++ b/FABToolbar/library/build.gradle
@@ -21,6 +21,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:design:23.0.1'
 }
 
 apply from: 'https://raw.github.com/fafaldo/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/FABToolbar/library/build.gradle
+++ b/FABToolbar/library/build.gradle
@@ -21,7 +21,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:design:23.0.1'
+    compile 'com.android.support:design:23.1.1'
 }
 
 apply from: 'https://raw.github.com/fafaldo/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/FABToolbar/library/src/main/java/com/github/fafaldo/fabtoolbar/widget/FABToolbarBehavior.java
+++ b/FABToolbar/library/src/main/java/com/github/fafaldo/fabtoolbar/widget/FABToolbarBehavior.java
@@ -1,0 +1,32 @@
+package com.github.fafaldo.fabtoolbar.widget;
+
+import android.content.Context;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.design.widget.Snackbar;
+import android.util.AttributeSet;
+import android.view.View;
+
+/**
+ * Created by Martin Perebner on 10/03/16.
+ */
+public class FABToolbarBehavior extends CoordinatorLayout.Behavior<FABToolbarLayout> {
+
+    public FABToolbarBehavior() {
+    }
+
+    public FABToolbarBehavior(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public boolean layoutDependsOn(CoordinatorLayout parent, FABToolbarLayout child, View dependency) {
+        return dependency instanceof Snackbar.SnackbarLayout;
+    }
+
+    @Override
+    public boolean onDependentViewChanged(CoordinatorLayout parent, FABToolbarLayout child, View dependency) {
+        float translationY = Math.min(0, dependency.getTranslationY() - dependency.getHeight());
+        child.setTranslationY(translationY);
+        return true;
+    }
+}

--- a/FABToolbar/library/src/main/java/com/github/fafaldo/fabtoolbar/widget/FABToolbarLayout.java
+++ b/FABToolbar/library/src/main/java/com/github/fafaldo/fabtoolbar/widget/FABToolbarLayout.java
@@ -12,6 +12,7 @@ import android.graphics.Point;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.TransitionDrawable;
 import android.os.Build;
+import android.support.design.widget.CoordinatorLayout;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
@@ -32,6 +33,7 @@ import java.util.List;
 /**
  * Created by rtulaza on 2015-07-30.
  */
+@CoordinatorLayout.DefaultBehavior(FABToolbarBehavior.class)
 public class FABToolbarLayout extends RelativeLayout {
 
     // anim timing


### PR DESCRIPTION
Added a CoordinatorLayout-Behavior for `FABToolbarLayout` in order to react to a `Snackbar`.

It behaves similar to the default-behavior of the `FloatingActionButton` meaning that the `FABToolbar` will shift to the top, independent of the current state (expended/collapsed).

I also added a showcase for the behavior in the Sample-Application - by long-clicking on an list-item a `Snackbar` will be shown and the `FABToolbar` should react accordingly.
